### PR TITLE
Tweak anchors (<Link>) and disable no-typos

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,15 @@ module.exports = {
     'import/prefer-default-export': 0,
     'prettier/prettier': ['error', { singleQuote: true, trailingComma: 'es5' }],
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+    'jsx-a11y/anchor-is-valid': [
+      'error',
+      {
+        components: ['Link'],
+        specialLink: ['to'],
+      },
+    ],
+    // Disable this because it does not yet handle custom proptypes.
+    // See: https://github.com/yannickcr/eslint-plugin-react/issues/1389
+    'react/no-typos': ['off'],
   },
 };


### PR DESCRIPTION
`<Link>` has a perfectly valid "to" attribute which gets rendered as a
"href", so this should not be a warning due to jsx-a11y/anchor-is-valid.

Additionally, disable react/no-typos until it can handle custom
proptypes.