### PR TITLE
Bump versions + no-force-destructure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     DEBUG: false,
   },
   rules: {
+    'react/destructuring-assignment': 0,
     'react/jsx-filename-extension': [0],
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,

--- a/package.json
+++ b/package.json
@@ -17,29 +17,29 @@
     "access": "public"
   },
   "devDependencies": {
-    "babel-eslint": ">=8",
-    "eslint": ">=4",
-    "eslint-config-airbnb": ">=16",
-    "eslint-config-prettier": ">=2",
+    "babel-eslint": ">=9",
+    "eslint": ">=5.6",
+    "eslint-config-airbnb": ">=17.1",
+    "eslint-config-prettier": ">=3",
     "eslint-plugin-import": ">=2",
     "eslint-plugin-jest": ">=2",
     "eslint-plugin-jsx-a11y": ">=6",
-    "eslint-plugin-prettier": ">=2",
-    "eslint-plugin-react": ">=7",
+    "eslint-plugin-prettier": ">=3",
+    "eslint-plugin-react": ">=7.11",
     "np": "*",
-    "prettier": ">=1"
+    "prettier": ">=1.14"
   },
   "peerDependencies": {
-    "babel-eslint": ">=8",
-    "eslint": ">=4",
-    "eslint-config-airbnb": ">=16",
-    "eslint-config-prettier": ">=2",
+    "babel-eslint": ">=9",
+    "eslint": ">=5.6",
+    "eslint-config-airbnb": ">=17.1",
+    "eslint-config-prettier": ">=3",
     "eslint-plugin-import": ">=2",
     "eslint-plugin-jest": ">=2",
     "eslint-plugin-jsx-a11y": ">=6",
-    "eslint-plugin-prettier": ">=2",
-    "eslint-plugin-react": ">=7",
-    "prettier": ">=1"
+    "eslint-plugin-prettier": ">=3",
+    "eslint-plugin-react": ">=7.11",
+    "prettier": ">=1.14"
   },
   "scripts": {
     "release": "np",


### PR DESCRIPTION
I'm updating our react-scripts fork at the same time I'll be bumping the verions of peer dependencies here.

I overrode one new default from react lint rules:
`react/destructuring-assignment` that forces you to always destructure all props.
This would force you to rename props that also are actions imported in the same file, super annoying.